### PR TITLE
🐛Exported repositoryBuilds properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,3 +387,4 @@ module.exports.orgConfigOverrides = orgConfigOverrides;
 module.exports.repoConfigDefaults = repoConfigDefaults;
 module.exports.repoConfigOverrides = repoConfigOverrides;
 module.exports.systemQueues = systemQueues;
+module.exports.repositoryBuilds = repositoryBuilds;


### PR DESCRIPTION
This PR fixes a bug where the `repositoryBuilds` wasn't properly exposed to apps.